### PR TITLE
fix: add race detector and fix race condition in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ deps:
 
 test:
 	@echo "Running tests..."
-	$(GOTEST) -v -coverprofile=coverage.out ./...
+	$(GOTEST) -race -v -coverprofile=coverage.out ./...
 	@echo "Tests complete"
 
 # Run end-to-end tests (tests CLI via Cobra ExecuteContext)
@@ -97,7 +97,7 @@ verify: deps
 	@echo "Checking formatting produced no changes..."
 	@git diff --exit-code
 	$(GOLINT) run ./...
-	$(GOTEST) -v -coverprofile=coverage.out ./...
+	$(GOTEST) -race -v -coverprofile=coverage.out ./...
 	@echo "All checks passed!"
 
 help:

--- a/internal/enricher/processor/batch_test.go
+++ b/internal/enricher/processor/batch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/spencercjh/spec-forge/internal/enricher/prompt"
@@ -15,11 +16,11 @@ type mockProvider struct {
 	response     string
 	responseFunc func() (string, error)
 	err          error
-	called       int
+	called       atomic.Int32
 }
 
 func (m *mockProvider) Generate(ctx context.Context, p string) (string, error) {
-	m.called++
+	m.called.Add(1)
 	if m.responseFunc != nil {
 		return m.responseFunc()
 	}
@@ -62,8 +63,8 @@ func TestBatchProcessor_ProcessBatch(t *testing.T) {
 		t.Fatalf("ProcessBatch() error = %v", err)
 	}
 
-	if mock.called != 1 {
-		t.Errorf("provider called %d times, want 1", mock.called)
+	if mock.called.Load() != 1 {
+		t.Errorf("provider called %d times, want 1", mock.called.Load())
 	}
 
 	// The SetValue should have been called with the full response
@@ -141,8 +142,8 @@ func TestConcurrentProcessor_ProcessAll(t *testing.T) {
 		t.Fatalf("ProcessAll() error = %v", err)
 	}
 
-	if mock.called != 2 {
-		t.Errorf("provider called %d times, want 2", mock.called)
+	if mock.called.Load() != 2 {
+		t.Errorf("provider called %d times, want 2", mock.called.Load())
 	}
 }
 

--- a/internal/extractor/spring/gradle.go
+++ b/internal/extractor/spring/gradle.go
@@ -52,7 +52,7 @@ func (p *GradleParser) ParseString(content string) (*model.Project, error) {
 func (p *GradleParser) GetSpringBootVersion(project *model.Project) string {
 	// Check plugins block for spring-boot
 	for _, plugin := range project.Plugins {
-		if plugin.ID == "org.springframework.boot" || plugin.ID == "spring-boot" {
+		if plugin.ID == springBootGroupID || plugin.ID == "spring-boot" {
 			if plugin.Version != "" {
 				return plugin.Version
 			}
@@ -104,7 +104,7 @@ func (p *GradleParser) HasSpringdocPlugin(project *model.Project) bool {
 // HasSpringBootPlugin checks if build.gradle has the Spring Boot plugin.
 func (p *GradleParser) HasSpringBootPlugin(project *model.Project) bool {
 	for _, plugin := range project.Plugins {
-		if plugin.ID == "org.springframework.boot" || plugin.ID == "spring-boot" {
+		if plugin.ID == springBootGroupID || plugin.ID == "spring-boot" {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

This PR adds the `-race` flag to go test commands and fixes the race condition that was detected.

## Changes

- **Makefile**: Add `-race` flag to `go test` commands in `test` and `verify` targets
- **internal/enricher/processor/batch_test.go**: Fix race condition in `mockProvider` by using `atomic.Int32` instead of `int` for the `called` field
- **internal/extractor/spring/gradle.go**: Fix `goconst` lint issue by using the existing `springBootGroupID` constant

## Race Condition Fix

The `TestConcurrentProcessor_ProcessAll` test runs batch processing concurrently. The `mockProvider.called` field was being read and written by multiple goroutines simultaneously, causing a data race. Using `sync/atomic.Int32` ensures thread-safe operations.

## Verification

All checks pass with race detector enabled:
```bash
make verify
# All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)