### PR TITLE
fix(test): remove unstable alias setters from PageResult for consistent OpenAPI generation

### DIFF
--- a/integration-tests/gradle-springboot-openapi-demo/src/main/java/com/example/openapi/controller/UserController.java
+++ b/integration-tests/gradle-springboot-openapi-demo/src/main/java/com/example/openapi/controller/UserController.java
@@ -61,8 +61,8 @@ public class UserController {
 
         PageResult<User> result = new PageResult<>();
         result.setContent(pageContent);
-        result.setPage(page);
-        result.setSize(size);
+        result.setPageNumber(page);
+        result.setPageSize(size);
         result.setTotal(allUsers.size());
         result.setTotalPages((int) Math.ceil((double) allUsers.size() / size));
 

--- a/integration-tests/gradle-springboot-openapi-demo/src/main/java/com/example/openapi/dto/PageResult.java
+++ b/integration-tests/gradle-springboot-openapi-demo/src/main/java/com/example/openapi/dto/PageResult.java
@@ -52,12 +52,4 @@ public class PageResult<T> {
     public void setTotalPages(int totalPages) {
         this.totalPages = totalPages;
     }
-
-    public void setPage(int pageNumber) {
-        this.pageNumber = pageNumber;
-    }
-
-    public void setSize(int pageSize) {
-        this.pageSize = pageSize;
-    }
 }

--- a/integration-tests/maven-springboot-openapi-demo/src/main/java/com/example/openapi/controller/UserController.java
+++ b/integration-tests/maven-springboot-openapi-demo/src/main/java/com/example/openapi/controller/UserController.java
@@ -61,8 +61,8 @@ public class UserController {
 
         PageResult<User> result = new PageResult<>();
         result.setContent(pageContent);
-        result.setPage(page);
-        result.setSize(size);
+        result.setPageNumber(page);
+        result.setPageSize(size);
         result.setTotal(allUsers.size());
         result.setTotalPages((int) Math.ceil((double) allUsers.size() / size));
 

--- a/integration-tests/maven-springboot-openapi-demo/src/main/java/com/example/openapi/dto/PageResult.java
+++ b/integration-tests/maven-springboot-openapi-demo/src/main/java/com/example/openapi/dto/PageResult.java
@@ -52,20 +52,4 @@ public class PageResult<T> {
     public void setTotalPages(int totalPages) {
         this.totalPages = totalPages;
     }
-
-    public int getPage() {
-        return pageNumber;
-    }
-
-    public void setPage(int pageNumber) {
-        this.pageNumber = pageNumber;
-    }
-
-    public int getSize() {
-        return pageSize;
-    }
-
-    public void setSize(int pageSize) {
-        this.pageSize = pageSize;
-    }
 }

--- a/integration-tests/spring/fixtures/golden/openapi.json
+++ b/integration-tests/spring/fixtures/golden/openapi.json
@@ -72,19 +72,11 @@
             },
             "type": "array"
           },
-          "page": {
-            "format": "int32",
-            "type": "integer"
-          },
           "pageNumber": {
             "format": "int32",
             "type": "integer"
           },
           "pageSize": {
-            "format": "int32",
-            "type": "integer"
-          },
-          "size": {
             "format": "int32",
             "type": "integer"
           },

--- a/integration-tests/spring/fixtures/golden/schemas/PageResultUser.json
+++ b/integration-tests/spring/fixtures/golden/schemas/PageResultUser.json
@@ -6,19 +6,11 @@
       },
       "type": "array"
     },
-    "page": {
-      "format": "int32",
-      "type": "integer"
-    },
     "pageNumber": {
       "format": "int32",
       "type": "integer"
     },
     "pageSize": {
-      "format": "int32",
-      "type": "integer"
-    },
-    "size": {
       "format": "int32",
       "type": "integer"
     },


### PR DESCRIPTION
## Summary

Fix intermittent `TestGoldenSnapshots` failures in CI caused by non-deterministic OpenAPI spec generation.

## Root Cause

`PageResult` class had **alias setters** (`setPage`, `setSize`) pointing to the same fields as the primary setters (`setPageNumber`, `setPageSize`). This caused springdoc-openapi to generate inconsistent specs across different JVM environments:

- **Local JDK**: Generated 7 properties (`page`, `size`, `pageNumber`, `pageSize`, etc.)
- **CI Temurin JDK**: Generated only 5 properties (`pageNumber`, `pageSize`, etc.)

## Changes

1. **PageResult.java** (both Maven and Gradle demo projects):
   - Removed alias setters `setPage(int)` and `setSize(int)`
   
2. **UserController.java** (both projects):
   - Updated to use `setPageNumber()` and `setPageSize()` instead of removed aliases

3. **Golden fixtures**:
   - Updated `PageResultUser.json` and `openapi.json` to match CI's stable output (5 properties instead of 7)

## Test Plan

- [x] Run `make test-e2e` locally - all tests pass
- [ ] CI E2E tests should pass with consistent golden comparisons

🤖 Generated with [Claude Code](https://claude.com/claude-code)